### PR TITLE
fix: correct Exception argument order in CronTimer (fixes #72)

### DIFF
--- a/blocks/CronTimer.mon
+++ b/blocks/CronTimer.mon
@@ -81,7 +81,7 @@ event CronTimer {
 	action $validate() {
 		float offset := currentTime - $base.getModelTime();
 		if offset > 10.0 {
-			throw Exception("OperationNotSupported", "Sorry, this does not support simulation mode, or maxInputDelay more than 10 seconds");
+			throw Exception("Sorry, this does not support simulation mode, or maxInputDelay more than 10 seconds", "OperationNotSupported");
 		}
 	}
 


### PR DESCRIPTION
Fixes #72.

`Exception(message, type)` is the signature used everywhere else in this repo (TimeOffset.mon, CreateOpcUAWrite.mon, CreateMeasurement.mon, IntervalPulseGenerator.mon, etc.) and documented in `.github/instructions/epl.instructions.md`. The `throw` in `CronTimer.mon:84` had the two arguments reversed, so the runtime error message was the type label and the type label was the message.